### PR TITLE
Add type definitions for `Pagination` class and `Places` class of the services library

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2121,6 +2121,11 @@ declare namespace daum.maps.services {
 
   export enum CategoryGroupCode {
     /**
+     * 코드 미부여
+     */
+    BLANK = '',
+    
+    /**
      * 대형마트
      */
     MT1 = 'MT1',

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for daum-map-api v3
-// Project: http://apis.map.daum.net/web/documentation/
+// Project: http://apis.map.kakao.com/web/documentation/
 // Definitions by: Hyeonsoo David Lee <https://github.com/civilizeddev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -7,7 +7,7 @@ declare namespace daum.maps {
   // Core
 
   /**
-   * @see [Circle](http://apis.map.daum.net/web/documentation/#Circle)
+   * @see [Circle](http://apis.map.kakao.com/web/documentation/#Circle)
    */
   export class Circle implements daum.maps.event.EventTarget {
     /**
@@ -158,7 +158,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [Coords](http://apis.map.daum.net/web/documentation/#Coords)
+   * @see [Coords](http://apis.map.kakao.com/web/documentation/#Coords)
    */
   export class Coords {
     /**
@@ -198,7 +198,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [CustomOverlay](http://apis.map.daum.net/web/documentation/#CustomOverlay)
+   * @see [CustomOverlay](http://apis.map.kakao.com/web/documentation/#CustomOverlay)
    */
   export class CustomOverlay implements daum.maps.event.EventTarget {
     /**
@@ -341,7 +341,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [LatLng](http://apis.map.daum.net/web/documentation/#LatLng)
+   * @see [LatLng](http://apis.map.kakao.com/web/documentation/#LatLng)
    */
   export class LatLng {
     /**
@@ -381,7 +381,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [LatLngBounds](http://apis.map.daum.net/web/documentation/#LatLngBounds)
+   * @see [LatLngBounds](http://apis.map.kakao.com/web/documentation/#LatLngBounds)
    */
   export class LatLngBounds {
     /**
@@ -418,7 +418,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [Map](http://apis.map.daum.net/web/documentation/#Map)
+   * @see [Map](http://apis.map.kakao.com/web/documentation/#Map)
    */
   export class Map implements daum.maps.event.EventTarget {
     /**
@@ -722,7 +722,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [MapProjection](http://apis.map.daum.net/web/documentation/#MapProjection)
+   * @see [MapProjection](http://apis.map.kakao.com/web/documentation/#MapProjection)
    */
   export class MapProjection {
     /**
@@ -759,7 +759,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [MapTypeId](http://apis.map.daum.net/web/documentation/#MapTypeId)
+   * @see [MapTypeId](http://apis.map.kakao.com/web/documentation/#MapTypeId)
    */
   export enum MapTypeId {
     /**
@@ -814,7 +814,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [Marker](http://apis.map.daum.net/web/documentation/#Marker)
+   * @see [Marker](http://apis.map.kakao.com/web/documentation/#Marker)
    */
   export class Marker implements daum.maps.event.EventTarget {
     /**
@@ -1022,7 +1022,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [MarkerImage](http://apis.map.daum.net/web/documentation/#MarkerImage)
+   * @see [MarkerImage](http://apis.map.kakao.com/web/documentation/#MarkerImage)
    */
   export class MarkerImage {
     /**
@@ -1069,14 +1069,14 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [MarkerClusterer](http://apis.map.daum.net/web/documentation/#MarkerClusterer)
+   * @see [MarkerClusterer](http://apis.map.kakao.com/web/documentation/#MarkerClusterer)
    */
   export class MarkerClusterer implements daum.maps.event.EventTarget {
     /**
      * 마커 클러스터링을 담당하는 객체.
      * clusterer 라이브러리를 별도 로드 해야 사용 가능하다.
      *
-     * @see [마커 클러스터러 사용하기 샘플보기](http://apis.map.daum.net/web/sample/basicClusterer/)
+     * @see [마커 클러스터러 사용하기 샘플보기](http://apis.map.kakao.com/web/sample/basicClusterer/)
      * @param options
      */
     constructor(options: MarkerClustererOptions)
@@ -1183,7 +1183,7 @@ declare namespace daum.maps {
     /**
      * 클러스터 내부에 표시할 문자열 배열 또는 문자열 생성 함수를 설정한다.
      *
-     * @see [클러스터 마커에 텍스트 표시하기 샘플보기](http://apis.map.daum.net/web/sample/chickenClusterer)
+     * @see [클러스터 마커에 텍스트 표시하기 샘플보기](http://apis.map.kakao.com/web/sample/chickenClusterer)
      * @param texts 클러스터 내부에 표시할 문자열 배열 또는 문자열 생성 함수
      */
     setTexts(texts: string[] | ((size: number) => string[])): void
@@ -1199,7 +1199,7 @@ declare namespace daum.maps {
      * 배열로 지정할 경우에는 반드시 오름차순으로 정렬해야 하며,
      * 생성함수로 지정할 경우에는 클러스터의 스타일 배열 인덱스 또는 텍스트(texts) 배열의 인덱스를 반환해야 한다.
      *
-     * @see [클러스터 마커에 텍스트 표시하기 샘플보기](http://apis.map.daum.net/web/sample/chickenClusterer)
+     * @see [클러스터 마커에 텍스트 표시하기 샘플보기](http://apis.map.kakao.com/web/sample/chickenClusterer)
      * @param calculator 클러스터의 크기를 구분하는 값의 배열 또는 구분값을 생성하는 함수
      */
     setCalculator(calculator: number[] | ((size: number) => number[])): void
@@ -1303,7 +1303,59 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [Point](http://apis.map.daum.net/web/documentation/#Point)
+   * @see [Pagination](http://apis.map.kakao.com/web/documentation/#Pagination)
+   */
+  export class Pagination {
+    /**
+     * 다음 페이지를 검색한다.
+     */
+    public nextPage(): void;
+
+    /**
+     * 이전 페이지를 검색한다.
+     */
+    public prevPage(): void;
+
+    /**
+     * 저장한 페이지를 검색한다.
+     * 
+     * @param page 페이지 번호
+     */
+    public gotoPage(page: number): void;
+
+    /**
+     * 가장 처음 페이지를 검색한다.
+     */
+    public gotoFirst(): void;
+
+    /**
+     * 가장 마지막 페이지를 검색한다.
+     */
+    public gotoLast(): void;
+
+    /**
+     * 현재 검색의 결과 목록의 총 갯수
+     */
+    totalCount: number;
+
+    /**
+     * 현재 검색 결과 기준, 다음 페이지가 있는지 여부
+     */
+    hasNextPage: boolean;
+
+    /**
+     * 현재 검색 결과 기준, 이 전 페이지가 있는지 여부
+     */
+    hasPrevPage: boolean;
+
+    /**
+     * 현재 페이지 번호
+     */
+    current: number;
+  }
+
+  /**
+   * @see [Point](http://apis.map.kakao.com/web/documentation/#Point)
    */
   export class Point {
     /**
@@ -1328,7 +1380,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [Polygon](http://apis.map.daum.net/web/documentation/#Polygon)
+   * @see [Polygon](http://apis.map.kakao.com/web/documentation/#Polygon)
    */
   export class Polygon implements daum.maps.event.EventTarget {
     /**
@@ -1439,7 +1491,7 @@ declare namespace daum.maps {
   /**
    * 폴리라인 객체
    *
-   * @see [Polyline](http://apis.map.daum.net/web/documentation/#Polyline)
+   * @see [Polyline](http://apis.map.kakao.com/web/documentation/#Polyline)
    */
   export class Polyline implements daum.maps.event.EventTarget {
     /**
@@ -1536,7 +1588,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [Rectangle](http://apis.map.daum.net/web/documentation/#Rectangle)
+   * @see [Rectangle](http://apis.map.kakao.com/web/documentation/#Rectangle)
    */
   export class Rectangle implements daum.maps.event.EventTarget {
     /**
@@ -1634,7 +1686,7 @@ declare namespace daum.maps {
   }
 
   /**
-   * @see [Size](http://apis.map.daum.net/web/documentation/#Size)
+   * @see [Size](http://apis.map.kakao.com/web/documentation/#Size)
    */
   export class Size {
     /**
@@ -1667,7 +1719,7 @@ declare namespace daum.maps {
    * 비동기 통신으로 페이지에 v3를 동적으로 삽입할 경우에 주로 사용된다.
    * v3 로딩 스크립트 주소에 파라메터로 autoload=false 를 지정해 주어야 한다.
    *
-   * @see [load](http://apis.map.daum.net/web/documentation/#load)
+   * @see [load](http://apis.map.kakao.com/web/documentation/#load)
    */
   export function load(callback: () => void): void
 
@@ -1676,7 +1728,7 @@ declare namespace daum.maps {
    * 모바일용 로드뷰도 고화질이 아닌 일반화질로 노출된다.
    * 반드시 Map 혹은 Roadview 객체를 선언하기 전에 호출해야 한다.
    *
-   * @see [disableHD](http://apis.map.daum.net/web/documentation/#disableHD)
+   * @see [disableHD](http://apis.map.kakao.com/web/documentation/#disableHD)
    */
   export function disableHD(): void
 
@@ -1684,7 +1736,7 @@ declare namespace daum.maps {
    * 지도 위에 올라가는 각종 도형의 선 스타일을 의미한다.
    * 스타일은 패턴에 따라 11종류가 있으며 그 값은 문자열로 지정한다.
    *
-   * @see [StrokeStyles](http://apis.map.daum.net/web/documentation/#StrokeStyles)
+   * @see [StrokeStyles](http://apis.map.kakao.com/web/documentation/#StrokeStyles)
    */
   export type StrokeStyles =
     | 'solid'
@@ -1755,7 +1807,7 @@ declare namespace daum.maps.event {
    * 마우스 이벤트로 넘겨 받는 인자
    * 직접 생성할 수는 없으며 이벤트 핸들러에서 내부적으로 생성된 객체를 parameter로 받아 사용한다.
    *
-   * @see [MouseEvent](http://apis.map.daum.net/web/documentation/#MouseEvent)
+   * @see [MouseEvent](http://apis.map.kakao.com/web/documentation/#MouseEvent)
    */
   export interface MouseEvent {
     /**
@@ -1791,7 +1843,7 @@ declare namespace daum.maps.services {
   /**
    * 주소-좌표간 변환 서비스 객체를 생성한다.
    *
-   * @see [Geocorder](http://apis.map.daum.net/web/documentation/#services_Geocoder)
+   * @see [Geocorder](http://apis.map.kakao.com/web/documentation/#services_Geocoder)
    */
   export class Geocoder {
     /**
@@ -1875,5 +1927,287 @@ declare namespace daum.maps.services {
      * 정상적으로 응답 받았으나 검색 결과는 없음
      */
     ZERO_RESULT = 'ZERO_RESULT',
+  }
+
+  /**
+   * 장소 검색 서비스.
+   *
+   * @see [Places](http://apis.map.kakao.com/web/documentation/#services_Places)
+   */
+  export class Places {
+    /**
+     * 장소 검색 서비스 객체를 생성한다.
+     *
+     * @param map 중심 좌표를 Places 객체의 location으로 설정할 지도 객체
+     */
+    constructor(map?: Map)
+
+    /**
+     * 지도 객체를 설정한다. 이미 설정되어 있는 지도는 `setMap(null)` 로 해제 가능하다.
+     *
+     * @param map 지도 객체
+     */
+    public setMap(map: Map | null): void
+
+    /**
+     * 입력한 키워드로 검색한다.
+     *
+     * @param keyword 검색할 키워드
+     * @param callback 검색 결과를 받을 콜백함수
+     * @param options
+     */
+    public keywordSearch(
+      keyword: string,
+      callback: (
+        result: PlacesSearchResult,
+        status: Status,
+        pagination: Pagination,
+      ) => void,
+      options?: PlacesSearchOptions,
+    ): void
+
+    /**
+     * 주어진 카테고리 코드로 검색한다.
+     * 카테고리 검색은 영역 검색이 기본이므로
+     * 옵션에 명세된 `x`, `y` 또는 `rect` 를 직접 지정하거나,
+     * `location` 또는 `bounds` 값을 넣어 주어야 한다.
+     * 아니면 지정한 `Map` 객체를 이용하는 옵션인 `useMapCenter` 또는
+     * `useMapBounds` 을 참으로 설정하여 지도의 영역이 자동으로
+     * 관련 값에 할당되도록 해도 된다.
+     *
+     * @param code 검색할 카테고리 코드
+     * @param callback 검색 결과를 받을 콜백함수
+     * @param options
+     */
+    public categorySearch(
+      code: CategoryGroupCode,
+      callback: (
+        result: PlacesSearchResult,
+        status: Status,
+        pagination: Pagination,
+      ) => void,
+      options?: PlacesSearchOptions,
+    ): void
+  }
+
+  export type PlacesSearchResult = PlacesSearchResultItem[]
+
+  export interface PlacesSearchResultItem {
+    /**
+     * 장소 ID
+     */
+    id: string
+
+    /**
+     * 장소명, 업체명
+     */
+    place_name: string
+
+    /**
+     * 카테고리 이름
+     * 예) 음식점 > 치킨
+     */
+    category_name: string
+
+    /**
+     * 중요 카테고리만 그룹핑한 카테고리 그룹 코드
+     * 예) FD6
+     */
+    category_group_code: CategoryGroupCode
+
+    /**
+     * 중요 카테고리만 그룹핑한 카테고리 그룹명
+     * 예) 음식점
+     */
+    category_group_name: string
+
+    /**
+     * 전화번호
+     */
+    phone: string
+
+    /**
+     * 전체 지번 주소
+     */
+    address_name: string
+
+    /**
+     * 전체 도로명 주소
+     */
+    road_address_name: string
+
+    /**
+     * X 좌표값 혹은 longitude
+     */
+    x: string
+
+    /**
+     * Y 좌표값 혹은 latitude
+     */
+    y: string
+
+    /**
+     * 장소 상세페이지 URL
+     */
+    place_url: string
+
+    /**
+     * 중심좌표까지의 거리(x,y 파라미터를 준 경우에만 존재). 단위 meter
+     */
+    distance: string
+  }
+
+  export interface PlacesSearchOptions {
+    /**
+     * 키워드 필터링을 위한 카테고리 코드
+     */
+    category_group_code?: CategoryGroupCode
+
+    /**
+     * 중심 좌표. 특정 지역을 기준으로 검색한다.
+     */
+    location?: LatLng
+
+    /**
+     * x 좌표, longitude, `location` 값이 있으면 무시된다.
+     */
+    x?: number
+
+    /**
+     * y 좌표, latitude, `location` 값이 있으면 무시된다.
+     */
+    y?: number
+
+    /**
+     * 중심 좌표로부터의 거리(반경) 필터링 값. `location` / `x`, `y` / `useMapCenter` 중 하나와 같이 써야 의미가 있음. 미터(m) 단위. 기본값은 5000, 0~20000까지 가능
+     */
+    radius?: number
+
+    /**
+     * 검색할 사각형 영역
+     */
+    bounds?: LatLngBounds
+
+    /**
+     * 사각 영역. 좌x,좌y,우x,우y 형태를 가짐. `bounds` 값이 있으면 무시된다.
+     */
+    rect?: string
+
+    /**
+     * 한 페이지에 보여질 목록 개수. 기본값은 15, 1~15까지 가능
+     */
+    size?: number
+
+    /**
+     * 검색할 페이지. 기본값은 1, `size` 값에 따라 1~45까지 가능
+     */
+    page?: number
+
+    /**
+     * 정렬 옵션. `DISTANCE` 일 경우 지정한 좌표값에 기반하여 동작함. 기본값은 `ACCURACY` (정확도 순)
+     */
+    sort?: SortBy
+
+    /**
+     * 지정한 Map 객체의 중심 좌표를 사용할지의 여부. 참일 경우, `location` 속성은 무시된다. 기본값은 false
+     */
+    useMapCenter?: boolean
+
+    /**
+     * 지정한 Map 객체의 영역을 사용할지의 여부. 참일 경우, `bounds` 속성은 무시된다. 기본값은 false
+     */
+    useMapBounds?: boolean
+  }
+
+  export enum CategoryGroupCode {
+    /**
+     * 대형마트
+     */
+    MT1 = 'MT1',
+
+    /**
+     * 편의점
+     */
+    CS2 = 'CS2',
+
+    /**
+     * 어린이집, 유치원
+     */
+    PS3 = 'PS3',
+
+    /**
+     * 학교
+     */
+    SC4 = 'SC4',
+
+    /**
+     * 학원
+     */
+    AC5 = 'AC5',
+
+    /**
+     * 주차장
+     */
+    PK6 = 'PK6',
+
+    /**
+     * 주유소, 충전소
+     */
+    OL7 = 'OL7',
+
+    /**
+     * 지하철역
+     */
+    SW8 = 'SW8',
+
+    /**
+     * 은행
+     */
+    BK9 = 'BK9',
+
+    /**
+     * 문화시설
+     */
+    CT1 = 'CT1',
+
+    /**
+     * 중개업소
+     */
+    AG2 = 'AG2',
+
+    /**
+     * 공공기관
+     */
+    PO3 = 'PO3',
+
+    /**
+     * 관광명소
+     */
+    AT4 = 'AT4',
+
+    /**
+     * 숙박
+     */
+    AD5 = 'AD5',
+
+    /**
+     * 음식점
+     */
+    FD6 = 'FD6',
+
+    /**
+     * 카페
+     */
+    CE7 = 'CE7',
+
+    /**
+     * 병원
+     */
+    HP8 = 'HP8',
+
+    /**
+     * 약국
+     */
+    PM9 = 'PM9',
   }
 }


### PR DESCRIPTION
`kakao.maps.services.Places` API를 쓸 일이 생겼는데 아직 정의가 안 되어 있어서 정의해서 pull request 보냅니다.

* `services.Places`의 타입 정의와 콜백 함수 타이핑에 필요한 `Pagination` class 정의가 추가되었습니다.
* API docs 페이지 변경에 따라 apis.map.daum.net -> apis.map.kakao.com 으로 일괄적으로 변경했습니다.
