### PR TITLE
Modified LatLngBounds class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -390,7 +390,7 @@ declare namespace daum.maps {
      * @param sw 사각 영역에서 남서쪽 좌표
      * @param ne 사각 영역에서 북동쪽 좌표
      */
-    constructor(sw: LatLng, ne: LatLng)
+    constructor(sw?: LatLng, ne?: LatLng)
 
     /**
      * 영역의 남서쪽 좌표를 반환한다.

--- a/index.d.ts
+++ b/index.d.ts
@@ -393,6 +393,23 @@ declare namespace daum.maps {
     constructor(sw?: LatLng, ne?: LatLng)
 
     /**
+     * 객체가 가지고 있는 영역 정보와 같은 영역 정보를 가지고 있는 객체인지 비교한다.
+     * 
+     * @param latlng
+     */
+    public equals(latlngBounds: LatLngBounds): boolean
+
+    /**
+     * 객체가 가지고 있는 영역 정보를 문자열로 반환한다.
+     */
+    public toString(): string
+
+    /**
+     * 영역 정ㅈ보가 비어있는지 확인한다.
+     */
+    public isEmpty():boolean
+
+    /**
      * 영역의 남서쪽 좌표를 반환한다.
      */
     public getSouthWest(): LatLng

--- a/index.d.ts
+++ b/index.d.ts
@@ -405,7 +405,7 @@ declare namespace daum.maps {
     public toString(): string
 
     /**
-     * 영역 정ㅈ보가 비어있는지 확인한다.
+     * 영역 정보가 비어있는지 확인한다.
      */
     public isEmpty():boolean
 


### PR DESCRIPTION
LatLngBounds 객체를 생성하는 중에 인자를 꼭 넣어야 하는 문제를 찾아 PR보냅니다.

1. LatLngBounds 객체 생성에 인자를 주지 않고 생성 하면 빈 영역을 생성합니다.
2. 새로 추가된 LatLngBounds Methods를 추가합니다.

http://apis.map.kakao.com/web/documentation/#LatLngBounds
